### PR TITLE
Fix snap service name. Eliminate unnecessary restarts, files.

### DIFF
--- a/charm/jmx-exporter/lib/charms/layer/jmxexporter.py
+++ b/charm/jmx-exporter/lib/charms/layer/jmxexporter.py
@@ -4,7 +4,7 @@ from charmhelpers.core import hookenv, host
 
 EXPORTER_PORT = 4081
 EXPORTER_SNAP = 'jmx-exporter'
-EXPORTER_SERVICE = 'snap.{}.jmx-exporter.service'.format(EXPORTER_SNAP)
+EXPORTER_SERVICE = 'snap.{}.jmx.service'.format(EXPORTER_SNAP)
 EXPORTER_COMMON = '/var/snap/{}/common'.format(EXPORTER_SNAP)
 
 

--- a/charm/jmx-exporter/reactive/jmxexporter.py
+++ b/charm/jmx-exporter/reactive/jmxexporter.py
@@ -1,5 +1,5 @@
-from charms.reactive import (when_any, when_not, set_flag,
-                             clear_flag, hook, when_file_changed)
+from charms.reactive import (when, when_any, when_not, when_none,
+                             set_flag, clear_flag, hook)
 from charms.reactive.helpers import data_changed
 
 from charmhelpers.core import hookenv
@@ -31,7 +31,15 @@ def config_changed():
     refresh()
 
 
-@when_file_changed(hookenv.config()['config'])
 @when_any('host-system.available', 'host-system.connected')
-def config_added():
+@when_not('jmx.connected')
+def host_added():
     refresh()
+    set_flag('jmx.connected')
+
+
+@when_none('host-system.available', 'host-system.connected')
+@when('jmx.connected')
+def host_removed():
+    refresh()
+    clear_flag('jmx.connected')


### PR DESCRIPTION
This change fixes a few issues I found:

The systemd service name differs slightly from the constant in the
charm, which prevented the service from automatically starting.

interface:juju-info flags remain set during the lifetime of the
relation, so another flag is used to only refresh the service once on
relation join.

The files/ subdirectory does not seem to be used any longer so it's been
removed.