### PR TITLE
Unconditionally refresh on config-changed.

### DIFF
--- a/charm/jmx-exporter/reactive/jmxexporter.py
+++ b/charm/jmx-exporter/reactive/jmxexporter.py
@@ -1,6 +1,5 @@
 from charms.reactive import (when, when_any, when_not, when_none,
                              set_flag, clear_flag, hook)
-from charms.reactive.helpers import data_changed
 
 from charmhelpers.core import hookenv
 
@@ -25,9 +24,6 @@ def waiting():
 
 @hook('config-changed')
 def config_changed():
-    if not data_changed('jmx_exporter.config', hookenv.config()['config']):
-        return
-
     refresh()
 
 


### PR DESCRIPTION
This hook will fire when config is changed, but also on upgrade-charm.
Because the hook and not a reactive flag is used, it is OK to
unconditionally refresh the service whether the config actually changed
or not. This ensures upgrade-charm can apply changes to the config that
might be in template or other charm updates.