### PR TITLE
Bump version to 0.12, use latest default jre.

### DIFF
--- a/charm/jmx-exporter/layer.yaml
+++ b/charm/jmx-exporter/layer.yaml
@@ -8,6 +8,7 @@ options:
   basic:
     packages:
       - default-jre-headless
+    include_system_packages: True
   snap:
     jmx-exporter:
       channel: edge

--- a/snap/local/jmx-exporter-wrapper.sh
+++ b/snap/local/jmx-exporter-wrapper.sh
@@ -7,4 +7,4 @@ if [ ! -f $SNAP_COMMON/config.yaml ]; then
 	exit 1
 fi
 
-java -jar $SNAP/jmx_prometheus_httpserver/jmx_prometheus_httpserver-0.11.0-jar-with-dependencies.jar 0.0.0.0:4081 $SNAP_COMMON/config.yaml
+java -jar $SNAP/jmx_prometheus_httpserver/jmx_prometheus_httpserver-0.12.0-jar-with-dependencies.jar 0.0.0.0:4081 $SNAP_COMMON/config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: jmx-exporter
 base: core18
-version: '0.11'
+version: '0.12'
 summary: Exposes JMX Beans via HTTP for Prometheus consumption
 description: |
   Exposes JMX Beans via HTTP for Prometheus consumption
@@ -17,10 +17,10 @@ apps:
 parts:
   build:
     stage-packages:
-      - openjdk-8-jre
+      - default-jre-headless
     plugin: maven
     source: https://github.com/prometheus/jmx_exporter.git
-    source-tag: parent-0.11.0
+    source-tag: parent-0.12.0
     source-type: git
     maven-options:
       - -DskipTests=true


### PR DESCRIPTION
A desperate attempt to mitigate
https://github.com/prometheus/jmx_exporter/issues/190 which is impacting
our staging environment at the moment.

Drive-by fix for layer:basic config, see https://discourse.jujucharms.com/t/heads-up-change-of-default-in-layer-basic/1562/3.